### PR TITLE
feat: SlimefunTranslation integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,5 +146,12 @@
             <version>3.0.0</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>net.guizhanss</groupId>
+            <artifactId>SlimefunTranslation</artifactId>
+            <version>ce9fb1c6f5</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/github/schntgaispock/slimehud/SlimeHUD.java
+++ b/src/main/java/io/github/schntgaispock/slimehud/SlimeHUD.java
@@ -4,6 +4,7 @@ package io.github.schntgaispock.slimehud;
 import javax.annotation.Nonnull;
 
 import io.github.schntgaispock.slimehud.placeholder.PlaceholderManager;
+import io.github.schntgaispock.slimehud.translation.TranslationManager;
 import io.github.schntgaispock.slimehud.waila.HudController;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
@@ -20,6 +21,7 @@ public class SlimeHUD extends AbstractAddon {
     @Getter AddonConfig playerData;
     static @Getter SlimeHUD instance;
     private HudController hudController;
+    private TranslationManager translationManager;
 
     public SlimeHUD() {
         super("SchnTgaiSpock", "SlimeHUD", "master", "options.auto-update");
@@ -51,6 +53,7 @@ public class SlimeHUD extends AbstractAddon {
         CommandManager.setup();
         PlaceholderManager.setup();
         hudController = new HudController();
+        translationManager = new TranslationManager();
     }
 
     @Override
@@ -61,6 +64,10 @@ public class SlimeHUD extends AbstractAddon {
 
     public static HudController getHudController() {
         return instance.hudController;
+    }
+
+    public static TranslationManager getTranslationManager() {
+        return instance.translationManager;
     }
 
     public static NamespacedKey newNamespacedKey(@Nonnull String name) {

--- a/src/main/java/io/github/schntgaispock/slimehud/translation/TranslationManager.java
+++ b/src/main/java/io/github/schntgaispock/slimehud/translation/TranslationManager.java
@@ -1,0 +1,37 @@
+package io.github.schntgaispock.slimehud.translation;
+
+import io.github.schntgaispock.slimehud.SlimeHUD;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import net.guizhanss.slimefuntranslation.SlimefunTranslation;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+public class TranslationManager {
+    private boolean translationEnabled;
+
+    public TranslationManager() {
+        if (SlimeHUD.getInstance().getConfig().getBoolean("options.slimefun-translation-support", true)) {
+            if (Bukkit.getPluginManager().getPlugin("SlimefunTranslation") != null) {
+                translationEnabled = true;
+            } else {
+                SlimeHUD.getInstance().getLogger().info("SlimefunTranslation is not installed and has been ignored.");
+                translationEnabled = false;
+            }
+        }
+    }
+
+    @Nonnull
+    @ParametersAreNonnullByDefault
+    public String getItemName(Player p, SlimefunItem sfItem) {
+        if (!translationEnabled) {
+            return sfItem.getItemName();
+        }
+        return SlimefunTranslation.getTranslationService().getTranslatedItemName(
+                SlimefunTranslation.getUserService().getUser(p),
+                sfItem
+        );
+    }
+}

--- a/src/main/java/io/github/schntgaispock/slimehud/waila/PlayerWAILA.java
+++ b/src/main/java/io/github/schntgaispock/slimehud/waila/PlayerWAILA.java
@@ -64,7 +64,7 @@ public class PlayerWAILA extends BukkitRunnable {
             return "";
 
         HudRequest request = new HudRequest(item, target, player);
-        StringBuilder text = new StringBuilder(item.getItemName())
+        StringBuilder text = new StringBuilder(SlimeHUD.getTranslationManager().getItemName(player, item))
                 .append(" ")
                 .append(ChatColor.translateAlternateColorCodes('&',
                         SlimeHUD.getHudController().processRequest(request)));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,9 @@ options:
   # Use PlaceholderAPI to get the player's toggle status
   placeholder-api-support: true
 
+  # Use SlimefunTranslation to display the translated name of items
+  slimefun-translation-support: true
+
 waila:
 
   # If set to true, will disable waila for all players,

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,6 +17,7 @@ depend:
 
 softdepend:
 - PlaceholderAPI
+- SlimefunTranslation
 
 commands:
   slimehud:


### PR DESCRIPTION
Get the translated item name for player when displaying WAILA.
If SlimefunTranslation is not installed, just display the default name.